### PR TITLE
Switch contact email function to Resend API

### DIFF
--- a/functions/contact.js
+++ b/functions/contact.js
@@ -1,3 +1,5 @@
+const RESEND_API_KEY = 're_2NoQNoJY_NhTkEQhobeGjsvpmZmadFTDT';
+
 export async function onRequestPost({ request }) {
   try {
     const { name, email, phone = '', company = '', message } = await request.json();
@@ -8,16 +10,19 @@ export async function onRequestPost({ request }) {
     const text = `お名前: ${name}\nメール: ${email}\n会社名: ${company || '(未記入)'}\n電話番号: ${phone || '(未記入)'}\n\n${message}`;
 
     const data = {
-      personalizations: [{ to: [{ email: 'info@stbshoukai.com' }] }],
-      from: { email: 'no-reply@stbshoukai.com', name: 'Contact Form' },
-      reply_to: { email, name },
+      from: 'Contact Form <no-reply@stbshoukai.com>',
+      to: ['info@stbshoukai.com'],
+      reply_to: email,
       subject: `お問い合わせ from ${name}`,
-      content: [{ type: 'text/plain', value: text }]
+      text
     };
 
-    const send = await fetch('https://api.mailchannels.net/tx/v1/send', {
+    const send = await fetch('https://api.resend.com/emails', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${RESEND_API_KEY}`
+      },
       body: JSON.stringify(data)
     });
 


### PR DESCRIPTION
## Summary
- use Resend for sending contact form emails

## Testing
- `node -e "import('./functions/contact.js').then(()=>console.log('ok')).catch(err=>console.error(err))"`


------
https://chatgpt.com/codex/tasks/task_e_68428b58b6908320aceed8344358baa8